### PR TITLE
Add answer column in the hunt's main page (closes #25)

### DIFF
--- a/myus/myus/models.py
+++ b/myus/myus/models.py
@@ -2,7 +2,7 @@ from django.db import models
 
 from django.contrib.auth.models import AbstractUser
 
-from django.db.models import OuterRef, Exists, Sum, Q
+from django.db.models import Subquery, OuterRef, Exists, Sum, Q
 
 from django.core.validators import MinValueValidator
 
@@ -153,8 +153,8 @@ class Team(models.Model):
 
     def unlocked_puzzles_with_solved(self):
         return self.unlocked_puzzles().annotate(
-            solved=Exists(
-                Guess.objects.filter(team=self, puzzle=OuterRef("pk"), correct=True)
+            correct_guess=Subquery(
+                Guess.objects.filter(team=self, puzzle=OuterRef("pk"), correct=True).values('guess')
             ),
         )
 

--- a/myus/myus/static/css/general.css
+++ b/myus/myus/static/css/general.css
@@ -75,6 +75,10 @@ table.classic th.small {
     font-size: 85%;
 }
 
+samp {
+	font-size: 1.2em;
+}
+
 h1 {
 	margin-top: 0;
 }

--- a/myus/myus/templates/view_hunt.html
+++ b/myus/myus/templates/view_hunt.html
@@ -26,11 +26,12 @@
 
 {% if puzzles %}
 <table class="classic">
-	<tr><th>Puzzle</th><th>Solved?</th><th>Solves</th><th>Guesses</th></tr>
+	<tr><th>Puzzle</th><th>Solved?</th><th>Answer</th><th>Solves</th><th>Guesses</th></tr>
 {% for puzzle in puzzles %}
 	<tr>
 		<td><a href="{% url 'view_puzzle' hunt.id hunt.slug puzzle.id puzzle.slug %}">{{ puzzle.name }}</a></td>
-		<td>{% if puzzle.solved %}✅{% endif %}</td>
+		<td>{% if puzzle.correct_guess %}✅{% endif %}</td>
+		<td>{% if puzzle.correct_guess %}{{ puzzle.correct_guess }}{% endif %}</td>
 		<td>{{ puzzle.solve_count }}</td>
 		<td>{{ puzzle.guess_count }}</td>
 	</tr>

--- a/myus/myus/templates/view_hunt.html
+++ b/myus/myus/templates/view_hunt.html
@@ -31,7 +31,7 @@
 	<tr>
 		<td><a href="{% url 'view_puzzle' hunt.id hunt.slug puzzle.id puzzle.slug %}">{{ puzzle.name }}</a></td>
 		<td>{% if puzzle.correct_guess %}✅{% endif %}</td>
-		<td>{% if puzzle.correct_guess %}{{ puzzle.correct_guess }}{% endif %}</td>
+		<td>{% if puzzle.correct_guess %}<samp>{{ puzzle.correct_guess }}</samp>{% endif %}</td>
 		<td>{{ puzzle.solve_count }}</td>
 		<td>{{ puzzle.guess_count }}</td>
 	</tr>


### PR DESCRIPTION
As described in #25, it would be useful to have the answer to solved puzzles visible in the hunt's main page. This PR adds the "Answer" column in the puzzle list which reveals answers as they are solved. Example of how this looks like:

![image](https://github.com/PuzzleTechHub/myus/assets/36921951/50ebc662-7131-4ec8-bbe2-14ec8ef1e52f)
