### PR TITLE
Display puzzles in a sandboxed iframe

### DIFF
--- a/myus/myus/static/css/general.css
+++ b/myus/myus/static/css/general.css
@@ -82,3 +82,11 @@ samp {
 h1 {
     margin-top: 0;
 }
+
+#puzzleframe {
+    background-color: transparent;
+    border: 0px none transparent;
+    padding: 0px;
+    overflow: hidden;
+    width: 100%;
+}

--- a/myus/myus/templates/base.html
+++ b/myus/myus/templates/base.html
@@ -86,6 +86,18 @@
                 node.textContent = new Date(Number(node.dataset.timestamp) * 1000).toLocaleString('en-CA');
                 node.setAttribute('title', 'Automatically converted to your time zone');
             });
+
+            function resizePuzzle(event) {
+                puzzle = document.getElementById("puzzleframe");
+                if(puzzle) {
+                    puzzle.style.height=(puzzle.contentDocument.body.scrollHeight+20)+"px";
+                    // the first line makes it long enough not to need scrollbars, but removing the scrollbar changes the height, so we do it again
+                    puzzle.style.height=(puzzle.contentDocument.body.scrollHeight+20)+"px";
+                }
+            }
+
+            addEventListener("resize", resizePuzzle);
+            addEventListener("load", resizePuzzle);
         </script>
     </body>
 </html>

--- a/myus/myus/templates/preview_markdown.html
+++ b/myus/myus/templates/preview_markdown.html
@@ -1,1 +1,6 @@
-{% load markdown %}{{ input|markdown }}
+{% load markdown %}
+
+<iframe id="puzzleframe"
+        sandbox="allow-same-origin allow-top-navigation"
+        srcdoc="{{input | markdown_srcdoc }}"
+        onload="resizePuzzle()"></iframe>

--- a/myus/myus/templates/view_puzzle.html
+++ b/myus/myus/templates/view_puzzle.html
@@ -94,5 +94,8 @@
 
     <hr />
 
-    {{ puzzle.content|markdown }}
+    <iframe id="puzzleframe"
+            sandbox="allow-same-origin allow-top-navigation"
+            srcdoc="{{puzzle.content | markdown_srcdoc }}">
+    </iframe>
 {% endblock %}

--- a/myus/myus/templates/view_puzzle_iframe.html
+++ b/myus/myus/templates/view_puzzle_iframe.html
@@ -1,0 +1,16 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link rel="stylesheet" href="{% static 'css/general.css' %}">
+        <link rel="shortcut icon" href="{% static 'favicon.ico' %}"/>
+        <title>{% block title %}myus{% endblock %}</title>
+    </head>
+    <body>
+        <base target="_parent">
+        {% load markdown %}
+        {{ puzzle | raw_markdown | safe}}
+    </body>
+</html>

--- a/myus/myus/templatetags/markdown.py
+++ b/myus/myus/templatetags/markdown.py
@@ -3,6 +3,8 @@ from django.utils.safestring import mark_safe
 from markdown import markdown as convert_markdown
 from bleach import Cleaner
 from bleach.linkifier import LinkifyFilter
+from django.utils.html import escape
+from django.template.loader import render_to_string
 
 register = template.Library()
 
@@ -44,3 +46,19 @@ cleaner = Cleaner(tags=SAFE_TAGS, filters=[LinkifyFilter])
 @register.filter
 def markdown(text):
     return mark_safe(cleaner.clean(convert_markdown(text, extensions=["extra"])))
+
+
+@register.filter
+def raw_markdown(text):
+    return convert_markdown(text, extensions=["extra"])
+
+
+@register.filter
+def markdown_srcdoc(text):
+    puzzle_iframe = render_to_string(
+        "view_puzzle_iframe.html",
+        {
+            "puzzle": text,
+        },
+    )
+    return escape(puzzle_iframe)


### PR DESCRIPTION
Puzzles and puzzle previews now display in a sandboxed iframe, and html tag filtering is removed. You can now put arbitrary HTML/CSS into a puzzle, but JavaScript execution is disabled, and the CSS only styles the puzzle, not the rest of the page.