### PR TITLE
Add edit hunt page

### DIFF
--- a/myus/myus/forms.py
+++ b/myus/myus/forms.py
@@ -68,7 +68,25 @@ class RegisterForm(forms.ModelForm):
         return user
 
 
-class HuntForm(forms.ModelForm):
+class NewHuntForm(forms.ModelForm):
+    description = forms.CharField(widget=MarkdownTextarea, required=False)
+    start_time = DateTimeLocalField(required=False, help_text="Date/time must be UTC")
+    end_time = DateTimeLocalField(required=False, help_text="Date/time must be UTC")
+
+    class Meta:
+        model = Hunt
+        fields = [
+            "name",
+            "slug",
+            "description",
+            "start_time",
+            "end_time",
+            "member_limit",
+            "guess_limit",
+        ]
+
+
+class EditHuntForm(forms.ModelForm):
     description = forms.CharField(widget=MarkdownTextarea, required=False)
     start_time = DateTimeLocalField(required=False, help_text="Date/time must be UTC")
     end_time = DateTimeLocalField(required=False, help_text="Date/time must be UTC")

--- a/myus/myus/models.py
+++ b/myus/myus/models.py
@@ -29,12 +29,12 @@ class Hunt(models.Model):
     start_time = models.DateTimeField(
         blank=True,
         null=True,
-        help_text="Start time of the hunt. If empty, the hunt will never begin. For indefinitely open hunts, you can just set it to any time in the past.",
+        help_text="(Not implemented) Start time of the hunt. If empty, the hunt will never begin. For indefinitely open hunts, you can just set it to any time in the past.",
     )
     end_time = models.DateTimeField(
         blank=True,
         null=True,
-        help_text="End date of the hunt. If empty, the hunt will always be open.",
+        help_text="(Not implemented) End date of the hunt. If empty, the hunt will always be open.",
     )
     organizers = models.ManyToManyField(User, related_name="organizing_hunts")
     invited_organizers = models.ManyToManyField(
@@ -47,7 +47,7 @@ class Hunt(models.Model):
     )
     member_limit = models.IntegerField(
         default=0,
-        help_text="The maximum number of members allowed per team; 0 means unlimited",
+        help_text="(Not implemented) The maximum number of members allowed per team; 0 means unlimited",
         validators=[MinValueValidator(0)],
     )
     guess_limit = models.IntegerField(

--- a/myus/myus/templates/edit_hunt.html
+++ b/myus/myus/templates/edit_hunt.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block nav %}
+    » Edit Hunt
+{% endblock %}
+{% block main %}
+    <h1>Edit Hunt</h1>
+    <form method="post">
+        {% csrf_token %}
+        {{ form.non_field_errors }}
+
+        <table class="classic">
+            {{ form.as_table }}
+        </table>
+        <input type="submit" value="Submit">
+    </form>
+
+{% endblock %}

--- a/myus/myus/templates/view_hunt.html
+++ b/myus/myus/templates/view_hunt.html
@@ -11,7 +11,9 @@
         </p>
 
         {% if is_organizer %}
-            <p>You are an organizer of this hunt. <a href="{% url 'new_puzzle' hunt.id hunt.slug %}">add puzzle</a></p>
+            <p>You are an organizer of this hunt:
+                <ul><li><a href="{% url 'new_puzzle' hunt.id hunt.slug %}">add puzzle</a></li>
+                    <li><a href="{% url 'edit_hunt' hunt.id hunt.slug %}">edit hunt settings</a></li></ul> </p>
         {% elif team %}
             <p>You are  <a href="{% url 'my_team' hunt.id hunt.slug %}">on Team {{ team.name }}</a>.</p>
         {% else %}

--- a/myus/myus/tests.py
+++ b/myus/myus/tests.py
@@ -4,7 +4,7 @@ from http import HTTPStatus
 from django.urls import reverse
 from django.test import TestCase
 
-from myus.forms import HuntForm
+from myus.forms import NewHuntForm
 from myus.models import Hunt, Puzzle, User
 
 
@@ -108,8 +108,8 @@ class TestViewPuzzle(TestCase):
         self.assertRedirects(res, self.correct_url)
 
 
-class TestHuntForm(TestCase):
-    """Test the HuntForm"""
+class TestNewHuntForm(TestCase):
+    """Test the NewHuntForm"""
 
     def setUp(self):
         self.shared_test_data = {
@@ -120,59 +120,59 @@ class TestHuntForm(TestCase):
         }
 
     def test_hunt_form_accepts_start_time_in_iso_format(self):
-        """The HuntForm accepts the start_time field in ISO format (YYYY-MM-DDTHH:MM:SS)"""
+        """The NewHuntForm accepts the start_time field in ISO format (YYYY-MM-DDTHH:MM:SS)"""
         test_data = self.shared_test_data.copy()
         start_time = datetime(2024, 3, 15, 1, 2, tzinfo=timezone.utc)
         test_data["start_time"] = start_time.isoformat()
-        form = HuntForm(data=test_data)
+        form = NewHuntForm(data=test_data)
         self.assertTrue(form.is_valid(), msg=form.errors)
         hunt = form.save()
         self.assertEqual(hunt.start_time, start_time)
 
     def test_hunt_form_accepts_start_time_without_seconds(self):
-        """The HuntForm accepts the start_time field without seconds specified
+        """The NewHuntForm accepts the start_time field without seconds specified
 
         The out-of-the-box datetime-local input appears to provide data in this format
         """
         test_data = self.shared_test_data.copy()
         start_time = datetime(2024, 3, 15, 1, 2, tzinfo=timezone.utc)
         test_data["start_time"] = start_time.strftime("%Y-%m-%dT%H:%M")
-        form = HuntForm(data=test_data)
+        form = NewHuntForm(data=test_data)
         self.assertTrue(form.is_valid(), msg=form.errors)
         hunt = form.save()
         self.assertEqual(hunt.start_time, start_time)
 
     def test_hunt_form_start_time_uses_datetime_local_input(self):
-        """The HuntForm uses a datetime-local input for the start_time field"""
-        form = HuntForm(data=self.shared_test_data)
+        """The NewHuntForm uses a datetime-local input for the start_time field"""
+        form = NewHuntForm(data=self.shared_test_data)
         start_time_field = form.fields["start_time"]
         self.assertEqual(start_time_field.widget.input_type, "datetime-local")
 
     def test_hunt_form_accepts_end_time_in_iso_format(self):
-        """The HuntForm accepts the end_time field in ISO format (YYYY-MM-DDTHH:MM:SS)"""
+        """The NewHuntForm accepts the end_time field in ISO format (YYYY-MM-DDTHH:MM:SS)"""
         test_data = self.shared_test_data.copy()
         end_time = datetime(2024, 3, 15, 1, 2, tzinfo=timezone.utc)
         test_data["end_time"] = end_time.isoformat()
-        form = HuntForm(data=test_data)
+        form = NewHuntForm(data=test_data)
         self.assertTrue(form.is_valid(), msg=form.errors)
         hunt = form.save()
         self.assertEqual(hunt.end_time, end_time)
 
     def test_hunt_form_accepts_end_time_without_seconds(self):
-        """The HuntForm accepts the end_time field without seconds specified
+        """The NewHuntForm accepts the end_time field without seconds specified
 
         The out-of-the-box datetime-local input appears to provide data in this format
         """
         test_data = self.shared_test_data.copy()
         end_time = datetime(2024, 3, 15, 1, 2, tzinfo=timezone.utc)
         test_data["end_time"] = end_time.strftime("%Y-%m-%dT%H:%M")
-        form = HuntForm(data=test_data)
+        form = NewHuntForm(data=test_data)
         self.assertTrue(form.is_valid(), msg=form.errors)
         hunt = form.save()
         self.assertEqual(hunt.end_time, end_time)
 
     def test_hunt_form_end_time_displays_datetime_local_widget(self):
-        """The HuntForm uses a datetime-local input for the end_time field"""
-        form = HuntForm(data=self.shared_test_data)
+        """The NewHuntForm uses a datetime-local input for the end_time field"""
+        form = NewHuntForm(data=self.shared_test_data)
         end_time_field = form.fields["end_time"]
         self.assertEqual(end_time_field.widget.input_type, "datetime-local")

--- a/myus/myus/urls.py
+++ b/myus/myus/urls.py
@@ -23,6 +23,8 @@ urlpatterns = [
     ),
     path("register", views.register, name="register"),
     path("new", views.new_hunt, name="new_hunt"),
+    path("hunt/<int:hunt_id>/edit", views.edit_hunt, name="edit_hunt"),
+    path("hunt/<int:hunt_id>-<slug:slug>/edit", views.edit_hunt, name="edit_hunt"),
     path("hunt/<int:hunt_id>", views.view_hunt, name="view_hunt"),
     path("hunt/<int:hunt_id>-<slug:slug>", views.view_hunt, name="view_hunt"),
     path("hunt/<int:hunt_id>/team", views.my_team, name="my_team"),


### PR DESCRIPTION
Adds an Edit Hunt page for hunt organizers. Currently, this shows the same settings as the New Hunt page.