### PR TITLE
Pre-TMPP changes

### DIFF
--- a/myus/myus/forms.py
+++ b/myus/myus/forms.py
@@ -68,7 +68,25 @@ class RegisterForm(forms.ModelForm):
         return user
 
 
-class HuntForm(forms.ModelForm):
+class NewHuntForm(forms.ModelForm):
+    description = forms.CharField(widget=MarkdownTextarea, required=False)
+    start_time = DateTimeLocalField(required=False, help_text="Date/time must be UTC")
+    end_time = DateTimeLocalField(required=False, help_text="Date/time must be UTC")
+
+    class Meta:
+        model = Hunt
+        fields = [
+            "name",
+            "slug",
+            "description",
+            "start_time",
+            "end_time",
+            "member_limit",
+            "guess_limit",
+        ]
+
+
+class EditHuntForm(forms.ModelForm):
     description = forms.CharField(widget=MarkdownTextarea, required=False)
     start_time = DateTimeLocalField(required=False, help_text="Date/time must be UTC")
     end_time = DateTimeLocalField(required=False, help_text="Date/time must be UTC")

--- a/myus/myus/forms.py
+++ b/myus/myus/forms.py
@@ -83,6 +83,7 @@ class NewHuntForm(forms.ModelForm):
             "end_time",
             "member_limit",
             "guess_limit",
+            "leaderboard_style",
         ]
 
 
@@ -101,6 +102,7 @@ class EditHuntForm(forms.ModelForm):
             "end_time",
             "member_limit",
             "guess_limit",
+            "leaderboard_style",
         ]
 
 

--- a/myus/myus/models.py
+++ b/myus/myus/models.py
@@ -55,6 +55,15 @@ class Hunt(models.Model):
         help_text="The default number of guesses teams get on each puzzle; 0 means unlimited",
         validators=[MinValueValidator(0)],
     )
+
+    class LeaderboardStyle(models.TextChoices):
+        DEFAULT = "DEF", "Default (ordered by score, solve count, and last solve time)"
+        HIDDEN = "HID", "Hidden (not displayed publicly)"
+        SPEEDRUN = "SPD", "Speedrun (ordered by score and time to solve)"
+
+    leaderboard_style = models.CharField(
+        max_length=3, choices=LeaderboardStyle, default=LeaderboardStyle.DEFAULT
+    )
     slug = models.SlugField(help_text="A short, unique identifier for the hunt.")
 
     def public_puzzles(self):

--- a/myus/myus/models.py
+++ b/myus/myus/models.py
@@ -29,12 +29,12 @@ class Hunt(models.Model):
     start_time = models.DateTimeField(
         blank=True,
         null=True,
-        help_text="Start time of the hunt. If empty, the hunt will never begin. For indefinitely open hunts, you can just set it to any time in the past.",
+        help_text="(Not implemented) Start time of the hunt. If empty, the hunt will never begin. For indefinitely open hunts, you can just set it to any time in the past.",
     )
     end_time = models.DateTimeField(
         blank=True,
         null=True,
-        help_text="End date of the hunt. If empty, the hunt will always be open.",
+        help_text="(Not implemented) End date of the hunt. If empty, the hunt will always be open.",
     )
     organizers = models.ManyToManyField(User, related_name="organizing_hunts")
     invited_organizers = models.ManyToManyField(
@@ -47,7 +47,7 @@ class Hunt(models.Model):
     )
     member_limit = models.IntegerField(
         default=0,
-        help_text="The maximum number of members allowed per team; 0 means unlimited",
+        help_text="(Not implemented) The maximum number of members allowed per team; 0 means unlimited",
         validators=[MinValueValidator(0)],
     )
     guess_limit = models.IntegerField(

--- a/myus/myus/templates/edit_hunt.html
+++ b/myus/myus/templates/edit_hunt.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block nav %}
+    » Edit Hunt
+{% endblock %}
+{% block main %}
+    <h1>Edit Hunt</h1>
+    <form method="post">
+        {% csrf_token %}
+        {{ form.non_field_errors }}
+
+        <table class="classic">
+            {{ form.as_table }}
+        </table>
+        <input type="submit" value="Submit">
+    </form>
+
+{% endblock %}

--- a/myus/myus/templates/leaderboard_SPD.html
+++ b/myus/myus/templates/leaderboard_SPD.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% load duration %}
+{% block nav %}
+    » <a href="{% url 'view_hunt' hunt.id hunt.slug %}">{{ hunt.name }}</a>
+    » Leaderboard
+{% endblock %}
+{% block main %}
+    <h1>Hunt: {{ hunt.name }} / Leaderboard</h1>
+
+    {% if teams %}
+        <table class="classic">
+            <tr><th>Team</th><th>Score</th><th>Solves</th><th>Team Creation Time (UTC)</th><th>Last Solve (UTC)</th><th>Total Solve Time</th></tr>
+            {% for team in teams %}
+                <tr>
+                    <td>{{ team.name }}</td>
+                    <td>{{ team.score }}</td>
+                    <td>{{ team.solve_count }}</td>
+                    <td>{{ team.creation_time|date:'Y-m-d H:i'}}</td>
+                    <td>{{ team.last_solve|date:'Y-m-d H:i'}}</td>
+                    <td>{{ team.solve_time|duration}}</td>
+                </tr>
+            {% endfor %}
+        </table>
+    {% else %}
+        No teams...
+    {% endif %}
+
+{% endblock %}

--- a/myus/myus/templates/my_team.html
+++ b/myus/myus/templates/my_team.html
@@ -6,7 +6,9 @@
 {% load user_display %}
 {% block main %}
     <h1>Hunt: {{ hunt.name }}</h1>
-    <a href="{% url 'leaderboard' hunt.id hunt.slug %}">leaderboard</a>
+    {% if hunt.leaderboard_style != "HID" %}
+        <a href="{% url 'leaderboard' hunt.id hunt.slug %}">leaderboard</a>
+    {% endif %}
 
     {% if error %}
         Error: {{ error }}

--- a/myus/myus/templates/view_hunt.html
+++ b/myus/myus/templates/view_hunt.html
@@ -33,7 +33,7 @@
                 <tr>
                     <td><a href="{% url 'view_puzzle' hunt.id hunt.slug puzzle.id puzzle.slug %}">{{ puzzle.name }}</a></td>
                     <td>{% if puzzle.correct_guess %}✅{% endif %}</td>
-                    <td>{% if puzzle.correct_guess %}<samp>{{ puzzle.correct_guess }}</samp>{% endif %}</td>
+                    <td>{% if puzzle.correct_guess %}<samp>{{ puzzle.answer | upper }}</samp>{% endif %}</td>
                     <td>{{ puzzle.solve_count }}</td>
                     <td>{{ puzzle.guess_count }}</td>
                 </tr>

--- a/myus/myus/templates/view_hunt.html
+++ b/myus/myus/templates/view_hunt.html
@@ -6,9 +6,11 @@
 {% block main %}
     <h1>Hunt: {{ hunt.name }}</h1>
     <nav class="nav-hunt">
-        <p>
-            <a href="{% url 'leaderboard' hunt.id hunt.slug %}">Leaderboard</a>
-        </p>
+        {% if hunt.leaderboard_style != "HID" or is_organizer %}
+            <p>
+                <a href="{% url 'leaderboard' hunt.id hunt.slug %}">Leaderboard</a>
+            </p>
+        {% endif %}
 
         {% if is_organizer %}
             <p>You are an organizer of this hunt:

--- a/myus/myus/templates/view_hunt.html
+++ b/myus/myus/templates/view_hunt.html
@@ -11,7 +11,9 @@
         </p>
 
         {% if is_organizer %}
-            <p>You are an organizer of this hunt. <a href="{% url 'new_puzzle' hunt.id hunt.slug %}">add puzzle</a></p>
+            <p>You are an organizer of this hunt:
+                <ul><li><a href="{% url 'new_puzzle' hunt.id hunt.slug %}">add puzzle</a></li>
+                    <li><a href="{% url 'edit_hunt' hunt.id hunt.slug %}">edit hunt settings</a></li></ul> </p>
         {% elif team %}
             <p>You are  <a href="{% url 'my_team' hunt.id hunt.slug %}">on Team {{ team.name }}</a>.</p>
         {% else %}

--- a/myus/myus/templates/view_puzzle.html
+++ b/myus/myus/templates/view_puzzle.html
@@ -59,7 +59,7 @@
                         <tr>
                             <td>
                                 {% if guess.correct %}
-                                    <strong>{{ guess.guess }}</strong>
+                                    <strong>{{ puzzle.answer | upper }}</strong>
                                 {% else %}
                                     {{ guess.guess }}
                                 {% endif %}

--- a/myus/myus/templatetags/duration.py
+++ b/myus/myus/templatetags/duration.py
@@ -1,0 +1,12 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def duration(td):
+    seconds = int(td.total_seconds())
+    (days, seconds) = divmod(seconds, 3600 * 24)
+    (hours, seconds) = divmod(seconds, 3600)
+    (minutes, seconds) = divmod(seconds, 60)
+    return "{} days {:02}:{:02}:{:02}".format(days, hours, minutes, seconds)

--- a/myus/myus/tests.py
+++ b/myus/myus/tests.py
@@ -4,7 +4,7 @@ from http import HTTPStatus
 from django.urls import reverse
 from django.test import TestCase
 
-from myus.forms import HuntForm
+from myus.forms import NewHuntForm
 from myus.models import Hunt, Puzzle, User
 
 
@@ -108,8 +108,8 @@ class TestViewPuzzle(TestCase):
         self.assertRedirects(res, self.correct_url)
 
 
-class TestHuntForm(TestCase):
-    """Test the HuntForm"""
+class TestNewHuntForm(TestCase):
+    """Test the NewHuntForm"""
 
     def setUp(self):
         self.shared_test_data = {
@@ -120,59 +120,59 @@ class TestHuntForm(TestCase):
         }
 
     def test_hunt_form_accepts_start_time_in_iso_format(self):
-        """The HuntForm accepts the start_time field in ISO format (YYYY-MM-DDTHH:MM:SS)"""
+        """The NewHuntForm accepts the start_time field in ISO format (YYYY-MM-DDTHH:MM:SS)"""
         test_data = self.shared_test_data.copy()
         start_time = datetime(2024, 3, 15, 1, 2, tzinfo=timezone.utc)
         test_data["start_time"] = start_time.isoformat()
-        form = HuntForm(data=test_data)
+        form = NewHuntForm(data=test_data)
         self.assertTrue(form.is_valid(), msg=form.errors)
         hunt = form.save()
         self.assertEqual(hunt.start_time, start_time)
 
     def test_hunt_form_accepts_start_time_without_seconds(self):
-        """The HuntForm accepts the start_time field without seconds specified
+        """The NewHuntForm accepts the start_time field without seconds specified
 
         The out-of-the-box datetime-local input appears to provide data in this format
         """
         test_data = self.shared_test_data.copy()
         start_time = datetime(2024, 3, 15, 1, 2, tzinfo=timezone.utc)
         test_data["start_time"] = start_time.strftime("%Y-%m-%dT%H:%M")
-        form = HuntForm(data=test_data)
+        form = NewHuntForm(data=test_data)
         self.assertTrue(form.is_valid(), msg=form.errors)
         hunt = form.save()
         self.assertEqual(hunt.start_time, start_time)
 
     def test_hunt_form_start_time_uses_datetime_local_input(self):
-        """The HuntForm uses a datetime-local input for the start_time field"""
-        form = HuntForm(data=self.shared_test_data)
+        """The NewHuntForm uses a datetime-local input for the start_time field"""
+        form = NewHuntForm(data=self.shared_test_data)
         start_time_field = form.fields["start_time"]
         self.assertEqual(start_time_field.widget.input_type, "datetime-local")
 
     def test_hunt_form_accepts_end_time_in_iso_format(self):
-        """The HuntForm accepts the end_time field in ISO format (YYYY-MM-DDTHH:MM:SS)"""
+        """The NewHuntForm accepts the end_time field in ISO format (YYYY-MM-DDTHH:MM:SS)"""
         test_data = self.shared_test_data.copy()
         end_time = datetime(2024, 3, 15, 1, 2, tzinfo=timezone.utc)
         test_data["end_time"] = end_time.isoformat()
-        form = HuntForm(data=test_data)
+        form = NewHuntForm(data=test_data)
         self.assertTrue(form.is_valid(), msg=form.errors)
         hunt = form.save()
         self.assertEqual(hunt.end_time, end_time)
 
     def test_hunt_form_accepts_end_time_without_seconds(self):
-        """The HuntForm accepts the end_time field without seconds specified
+        """The NewHuntForm accepts the end_time field without seconds specified
 
         The out-of-the-box datetime-local input appears to provide data in this format
         """
         test_data = self.shared_test_data.copy()
         end_time = datetime(2024, 3, 15, 1, 2, tzinfo=timezone.utc)
         test_data["end_time"] = end_time.strftime("%Y-%m-%dT%H:%M")
-        form = HuntForm(data=test_data)
+        form = NewHuntForm(data=test_data)
         self.assertTrue(form.is_valid(), msg=form.errors)
         hunt = form.save()
         self.assertEqual(hunt.end_time, end_time)
 
     def test_hunt_form_end_time_displays_datetime_local_widget(self):
-        """The HuntForm uses a datetime-local input for the end_time field"""
-        form = HuntForm(data=self.shared_test_data)
+        """The NewHuntForm uses a datetime-local input for the end_time field"""
+        form = NewHuntForm(data=self.shared_test_data)
         end_time_field = form.fields["end_time"]
         self.assertEqual(end_time_field.widget.input_type, "datetime-local")

--- a/myus/myus/urls.py
+++ b/myus/myus/urls.py
@@ -23,6 +23,8 @@ urlpatterns = [
     ),
     path("register", views.register, name="register"),
     path("new", views.new_hunt, name="new_hunt"),
+    path("hunt/<int:hunt_id>/edit", views.edit_hunt, name="edit_hunt"),
+    path("hunt/<int:hunt_id>-<slug:slug>/edit", views.edit_hunt, name="edit_hunt"),
     path("hunt/<int:hunt_id>", views.view_hunt, name="view_hunt"),
     path("hunt/<int:hunt_id>-<slug:slug>", views.view_hunt, name="view_hunt"),
     path("hunt/<int:hunt_id>/team", views.my_team, name="my_team"),

--- a/myus/myus/views.py
+++ b/myus/myus/views.py
@@ -566,7 +566,7 @@ def edit_hunt(
         raise PermissionDenied
 
     if request.method == "POST":
-        form = EditHuntForm(request.POST)
+        form = EditHuntForm(request.POST, instance=hunt)
         if form.is_valid():
             hunt = form.save()
             return redirect(urls.reverse("view_hunt", args=[hunt.pk, hunt.slug]))


### PR DESCRIPTION
- Add a page to edit hunt settings (name, description, etc.)
- Add settings for leaderboard (Default, Speedrun, Hidden)
   - Default: Sort by score, solve count, and time of last solve
   - Speedrun: Sort by score, solve count, and time between team creation and last solve (Note: Set the hunt start time to the time that puzzles were made available so that solvers aren't penalized for creating teams early)
   - Hidden: Hide leaderboard except for organizers
- Display correct guesses as the puzzle answer input in the backend

