### PR TITLE
tweak solution visibility for logged-in users

### DIFF
--- a/myus/myus/views.py
+++ b/myus/myus/views.py
@@ -332,6 +332,7 @@ def view_puzzle(
             or (
                 hunt.solution_style == Hunt.SolutionStyle.AFTER_SOLVE
                 and hunt.is_archived()
+                and team is None
             )
         ):
             show_solution = True


### PR DESCRIPTION
Make solutions visible to users who aren't on a team in archive mode, but locked for unsolved puzzles for logged-in users.